### PR TITLE
[feat] contract 수정을 통한 다른 api의 수정 기능

### DIFF
--- a/src/modules/contracts/contracts-repository.ts
+++ b/src/modules/contracts/contracts-repository.ts
@@ -1,8 +1,8 @@
 import prisma from '../../lib/prisma';
-import type { Prisma } from '@prisma/client';
+import type { Prisma, CarStatusEnum } from '@prisma/client';
 
 export const contractRepository = {
-  findCarById: (id: number) => prisma.car.findUnique({ where: { id }, include: { model: true } }),
+  findCarByIdWithStatus: (id: number, status: CarStatusEnum) => prisma.car.findFirst({ where: { id, status }, include: { model: true } }),
 
   findCustomerById: (id: number) => prisma.customer.findUnique({ where: { id } }),
 
@@ -79,11 +79,9 @@ export const contractRepository = {
       },
     }),
 
-  deleteContract: (id: number) => prisma.contract.delete({ where: { id } }),
-
-  findCarsByCompany: (companyId: number) =>
+  findCarsByCompany: (companyId: number, status: CarStatusEnum) =>
     prisma.car.findMany({
-      where: { companyId },
+      where: { companyId, status },
       select: { id: true, carNumber: true, model: { select: { modelName: true } } },
     }),
 
@@ -97,5 +95,11 @@ export const contractRepository = {
     prisma.user.findMany({
       where: { companyId },
       select: { id: true, name: true, email: true },
+    }),
+
+  updateCarStatus: (carId: number, status: CarStatusEnum) =>
+    prisma.car.update({
+      where: { id: carId },
+      data: { status },
     }),
 };


### PR DESCRIPTION
contract의 update 시, car status 변경, customer의 contractCount의 변경 기능을 추가했습니다.
그리고 저희끼리 정의 내린 계약 성공, 실패 시, 다시 이전 단계로 돌릴 수 없는 기능에서 백엔드 내 오류로 처리되는게 괜찮은지 잘 몰라서 이곳에서 한번 더 언급해 둡니다.